### PR TITLE
feat(ui): Add option to select only folders for tree generation

### DIFF
--- a/DirectoryTree2TXT/Services/DirectoryTreeGenerator.cs
+++ b/DirectoryTree2TXT/Services/DirectoryTreeGenerator.cs
@@ -18,7 +18,7 @@ namespace DirectoryTreeViewer.Services
         /// <param name="exclusions">Optional list of exclusions.</param>
         /// <param name="showContents">Flag to indicate whether file contents should be shown.</param>
         /// <returns>A string representing the directory tree.</returns>
-        public string GenerateTree(string rootPath, string indent = "", bool isLast = true, List<ExclusionEntry>? exclusions = null, bool showContents = false)
+        public string GenerateTree(string rootPath, string indent = "", bool isLast = true, List<ExclusionEntry>? exclusions = null, bool showContents = false, bool showOnlyFolders = false)
         {
             string tree = indent;
             if (!string.IsNullOrEmpty(indent))
@@ -33,7 +33,8 @@ namespace DirectoryTreeViewer.Services
             try
             {
                 children.AddRange(Directory.GetDirectories(rootPath).Select(d => (true, d)));
-                children.AddRange(Directory.GetFiles(rootPath).Select(f => (false, f)));
+                if (!showOnlyFolders)
+                    children.AddRange(Directory.GetFiles(rootPath).Select(f => (false, f)));
             }
             catch (UnauthorizedAccessException)
             {
@@ -66,7 +67,7 @@ namespace DirectoryTreeViewer.Services
                     }
                     else
                     {
-                        tree += GenerateTree(child.path, newIndent, childIsLast, exclusions, showContents);
+                        tree += GenerateTree(child.path, newIndent, childIsLast, exclusions, showContents, showOnlyFolders);
                     }
                 }
                 else

--- a/DirectoryTree2TXT/ViewModels/MainWindowViewModel.cs
+++ b/DirectoryTree2TXT/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ namespace DirectoryTreeViewer.ViewModels
         private string _directoryPath = string.Empty;
         private string _treeOutput = string.Empty;
         private bool _showContents;
+        private bool _showOnlyFolders;
         private string _newEntryName = string.Empty;
         private ConfigurationFileViewModel? _selectedConfiguration; // Backing field added
 
@@ -37,6 +38,12 @@ namespace DirectoryTreeViewer.ViewModels
         {
             get => _showContents;
             set { _showContents = value; OnPropertyChanged(); }
+        }
+
+        public bool ShowOnlyFolders
+        {
+            get => _showOnlyFolders;
+            set { _showOnlyFolders = value; OnPropertyChanged(); }
         }
 
         public string NewEntryName
@@ -119,7 +126,7 @@ namespace DirectoryTreeViewer.ViewModels
             if (Directory.Exists(DirectoryPath))
             {
                 var exclusions = ExclusionEntries?.ToList() ?? new List<ExclusionEntry>(); // Fix null issue
-                TreeOutput = _directoryTreeGenerator.GenerateTree(DirectoryPath, "", true, exclusions, ShowContents);
+                TreeOutput = _directoryTreeGenerator.GenerateTree(DirectoryPath, "", true, exclusions, ShowContents, ShowOnlyFolders);
             }
             else
             {

--- a/DirectoryTree2TXT/Views/MainWindow.xaml
+++ b/DirectoryTree2TXT/Views/MainWindow.xaml
@@ -146,13 +146,17 @@
                       Command="{Binding ClearEntriesCommand}"/>
                         </StackPanel>
 
-                        <!-- Checkbox Row -->
-                        <CheckBox x:Name="ShowContentsCheckBox"
-                      Content="Show File Contents"
-                      IsChecked="{Binding ShowContents}"
-                      Margin="0,10,0,0"
-                      Grid.Row="1"/>
-
+                        <StackPanel Orientation="Horizontal" Margin="0,10,0,0" Grid.Row="1">
+                            <!-- Checkbox Row -->
+                            <CheckBox x:Name="ShowContentsCheckBox"
+                            Content="Show File Contents"
+                            IsChecked="{Binding ShowContents}"
+                            Margin="0,10,0,0"/>
+                            <CheckBox x:Name="ShowOnlyFolders"
+                            Content="Show Only Folders"
+                            IsChecked="{Binding ShowOnlyFolders}"
+                            Margin="10,10,0,0"/>
+                        </StackPanel>
                         <!-- Exclusion Entries DataGrid -->
                         <Grid Grid.Row="2" Margin="0,10,0,0">
                             <Grid.Style>


### PR DESCRIPTION
Introduced a new option that allows users to restrict selection to folders when generating the tree structure.